### PR TITLE
Fixing some issues with makeFastq task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,4 @@
+## 1.0.1 - 2022-01-18
+ - Revising workflow, additional parameters for picard task
 ## 1.0.0 - 2022-01-13
  - Releasing for Vidarr

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Parameter|Value|Default|Description
 `makeFastq.overhead`|Int|6|Ovrerhead for calculating heap memory, difference between total and Java-allocated memory
 `makeFastq.timeout`|Int|20|Timeout in hours, needed to override imposed limits.
 `makeFastq.bamNameIndexJar`|String|"$HLA_VBSEQ_ROOT/bin/bamNameIndex.jar"|Jar file for bamNameInder
+`makeFastq.picardParams`|String|"VALIDATION_STRINGENCY=LENIENT"|Additional parameters for picard SamToFastq, Default is VALIDATION_STRINGENCY=LENIENT
 `makeFastq.modules`|String|"samtools/1.9 picard/2.21.2"|Names and versions of required modules.
 `bwaMem.adapterTrimmingLog_timeout`|Int|48|Hours before task timeout
 `bwaMem.adapterTrimmingLog_jobMemory`|Int|12|Memory allocated indexing job
@@ -104,7 +105,7 @@ Parameter|Value|Default|Description
 `callHlaDigits.resolution`|Int|4|Resolution for HLA allele may be 4, 6 or 8
 `callHlaDigits.callingScript`|String|"$HLA_VBSEQ_ROOT/bin/call_hla_digits.py"|Path to the HLA allele calling script
 `callHlaDigits.alleleFile`|String|"$HLAVBSEQ_BWA_INDEX_ROOT/Allelelist.txt"|File with allele information
-`callHlaDigits.modules`|String|"hlavbseq/1 hlaminer-bwa-index/0.7.17"|Names and versions of required modules.
+`callHlaDigits.modules`|String|"hla-vbseq/1 hlavbseq-bwa-index/2.0"|Names and versions of required modules.
 
 
 ### Outputs

--- a/commands.txt
+++ b/commands.txt
@@ -5,14 +5,14 @@ This section lists command(s) run by HLA-VBseq workflow
 
 At this point, workflow uses a filtering step for alignments (removing secondary hits) which is not a part of the standard way to run this tool. It may be resolved in a future, but since the authors did not publish the source code it may require direct communication with them to clarify some issues. The workflow produces reports as expected, though filtering of reads may distort the assessment of HLA alleles.
 
-###Extracting reads which overlap HLA alleles:
+### Extracting reads which overlap HLA alleles:
 
 ```
  samtools view INPUT_BAM HLA_INTERVALS | awk '{print $1}' | sort | uniq > [OUTPUT_PREFIX]_HLA-VBSeq_reads.txt
 
 ```
 
-###Indexing bam file with HLA-VBseq and extracting HLA reads into a .sam file
+### Indexing bam file with HLA-VBseq and extracting HLA reads into a .sam file
 
 ```
  set -euo pipefail
@@ -23,7 +23,7 @@ At this point, workflow uses a filtering step for alignments (removing secondary
  java -Xmx18G -jar BAM_NAME_INDEX_JAR search data/FILE_NAME --name HLA_READS --output [FILE_NAME]_partial.sam
 ```
 
-###Extract reads into fastq files, both for HLA-specific and unmapped reads. Merge.
+### Extract reads into fastq files, both for HLA-specific and unmapped reads. Merge.
 
 ```
  set -euo pipefail
@@ -36,13 +36,13 @@ At this point, workflow uses a filtering step for alignments (removing secondary
 
 ```
 
-###Filter alignments (the default is to remove secondary alignments)
+### Filter alignments (the default is to remove secondary alignments)
 
 ```
  samtools view -h -F FILTER_TAG INPUT_BAM -b > FILTERED_BAM
 ```
 
-###Run the analysis with HLA-VBseq, call HLA alleles
+### Run the analysis with HLA-VBseq, call HLA alleles
 
 ```
  set -euo pipefail
@@ -54,7 +54,7 @@ At this point, workflow uses a filtering step for alignments (removing secondary
                            --alpha_zero ALPHA_ZERO \
                            --is_paired 
 ```
-###Parsing raw calls from HLA-VBseq
+### Parsing raw calls from HLA-VBseq
 
 ```
  ~{parsingScript} ALLELE_FILE \
@@ -62,7 +62,7 @@ At this point, workflow uses a filtering step for alignments (removing secondary
                   [FILE_NAME]_HLA-VBSeq_prediction.txt
 ```
 
-###Post-processing of the results
+### Post-processing of the results
 
 ```
  python3 CALLING_SCRIPT \

--- a/hlavbseq.wdl
+++ b/hlavbseq.wdl
@@ -214,6 +214,7 @@ input {
   File hlaReads
   String bamNameIndexJar = "$HLA_VBSEQ_ROOT/bin/bamNameIndex.jar"
   String outputFileNamePrefix
+  String picardParams = "VALIDATION_STRINGENCY=LENIENT"
   String modules = "samtools/1.9 picard/2.21.2"
 }
 
@@ -222,9 +223,9 @@ Int javaMemory = jobMemory - overhead
 command <<<
  set -euo pipefail
  unset _JAVA_OPTIONS
- java -Xmx~{javaMemory}G -jar $PICARD_ROOT/picard.jar SamToFastq I=~{partialSam} F=PARTIAL_1.fastq F2=PARTIAL_2.fastq
+ java -Xmx~{javaMemory}G -jar $PICARD_ROOT/picard.jar SamToFastq I=~{partialSam} F=PARTIAL_1.fastq F2=PARTIAL_2.fastq ~{picardParams}
  samtools view -bh -f 12 ~{inputBam} > ~{outputFileNamePrefix}.sorted_unmapped.bam
- java -Xmx~{javaMemory}G -jar $PICARD_ROOT/picard.jar SamToFastq I=~{outputFileNamePrefix}.sorted_unmapped.bam F=UNMAPPED_1.fastq F2=UNMAPPED_2.fastq
+ java -Xmx~{javaMemory}G -jar $PICARD_ROOT/picard.jar SamToFastq I=~{outputFileNamePrefix}.sorted_unmapped.bam F=UNMAPPED_1.fastq F2=UNMAPPED_2.fastq ~{picardParams}
  cat PARTIAL_1.fastq UNMAPPED_1.fastq | gzip -c > ~{outputFileNamePrefix}_part_1.fastq.gz
  cat PARTIAL_2.fastq UNMAPPED_2.fastq | gzip -c > ~{outputFileNamePrefix}_part_2.fastq.gz
 
@@ -237,6 +238,7 @@ parameter_meta {
  outputFileNamePrefix: "Output prefix for the result file"
  jobMemory: "Memory allocated to the task."
  overhead: "Ovrerhead for calculating heap memory, difference between total and Java-allocated memory"
+ picardParams: "Additional parameters for picard SamToFastq, Default is VALIDATION_STRINGENCY=LENIENT"
  modules: "Names and versions of required modules."
  timeout: "Timeout in hours, needed to override imposed limits."
 }
@@ -399,7 +401,7 @@ input {
   String callingScript = "$HLA_VBSEQ_ROOT/bin/call_hla_digits.py"
   String alleleFile = "$HLAVBSEQ_BWA_INDEX_ROOT/Allelelist.txt"
   String outputFileNamePrefix
-  String modules = "hlavbseq/1 hlaminer-bwa-index/0.7.17"
+  String modules = "hla-vbseq/1 hlavbseq-bwa-index/2.0"
 }
 
 command <<<

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -79,6 +79,7 @@
                 "type": "EXTERNAL"
             },
 	    "hlavbseq.makeFastq.bamNameIndexJar": null,
+            "hlavbseq.makeFastq.picardParams": null,
 	    "hlavbseq.makeFastq.jobMemory": null,
 	    "hlavbseq.makeFastq.modules": null,
 	    "hlavbseq.makeFastq.overhead": null,


### PR DESCRIPTION
In this pull request, I am adding an additional parameter for **makeFastq** task. If needed, we can pass more parameters to Picard which may misbehave in some cases. By default, it is set to VALIDATION_STRINGENCY=LENIENT